### PR TITLE
Support scope variables in URIs

### DIFF
--- a/apicontext.go
+++ b/apicontext.go
@@ -151,6 +151,7 @@ func (ctx *ApiContext) ISetQueryParamsTo(dt *godog.Table) error {
 
 // ISendRequestTo Sends a request to the specified endpoint using the specified method.
 func (ctx *ApiContext) ISendRequestTo(method, uri string) error {
+	uri = ctx.ReplaceScopeVariables(uri)
 	reqURL := fmt.Sprintf("%s%s", ctx.baseURL, uri)
 
 	req, err := http.NewRequest(method, reqURL, nil)
@@ -200,7 +201,7 @@ func (ctx *ApiContext) ISendRequestTo(method, uri string) error {
 
 // ISendRequestToWithFormBody Send a request with json body. Ex: a POST request.
 func (ctx *ApiContext) ISendRequestToWithFormBody(method, uri string, requestBodyTable *godog.Table) error {
-
+	uri = ctx.ReplaceScopeVariables(uri)
 	reqURL := fmt.Sprintf("%s%s", ctx.baseURL, uri)
 
 	reqBody := &bytes.Buffer{}
@@ -277,7 +278,7 @@ func (ctx *ApiContext) ISendRequestToWithFormBody(method, uri string, requestBod
 
 // ISendRequestToWithBody Send a request with json body. Ex: a POST request.
 func (ctx *ApiContext) ISendRequestToWithBody(method, uri string, requestBody *godog.DocString) error {
-
+	uri = ctx.ReplaceScopeVariables(uri)
 	reqURL := fmt.Sprintf("%s%s", ctx.baseURL, uri)
 	jsonBody := ctx.ReplaceScopeVariables(requestBody.Content)
 	//todo

--- a/apicontext.go
+++ b/apicontext.go
@@ -151,9 +151,7 @@ func (ctx *ApiContext) ISetQueryParamsTo(dt *godog.Table) error {
 
 // ISendRequestTo Sends a request to the specified endpoint using the specified method.
 func (ctx *ApiContext) ISendRequestTo(method, uri string) error {
-	uri = ctx.ReplaceScopeVariables(uri)
-	reqURL := fmt.Sprintf("%s%s", ctx.baseURL, uri)
-
+	reqURL := ctx.buildRequestURL(uri)
 	req, err := http.NewRequest(method, reqURL, nil)
 
 	if err != nil {
@@ -201,9 +199,7 @@ func (ctx *ApiContext) ISendRequestTo(method, uri string) error {
 
 // ISendRequestToWithFormBody Send a request with json body. Ex: a POST request.
 func (ctx *ApiContext) ISendRequestToWithFormBody(method, uri string, requestBodyTable *godog.Table) error {
-	uri = ctx.ReplaceScopeVariables(uri)
-	reqURL := fmt.Sprintf("%s%s", ctx.baseURL, uri)
-
+	reqURL := ctx.buildRequestURL(uri)
 	reqBody := &bytes.Buffer{}
 	w := multipart.NewWriter(reqBody)
 
@@ -278,8 +274,7 @@ func (ctx *ApiContext) ISendRequestToWithFormBody(method, uri string, requestBod
 
 // ISendRequestToWithBody Send a request with json body. Ex: a POST request.
 func (ctx *ApiContext) ISendRequestToWithBody(method, uri string, requestBody *godog.DocString) error {
-	uri = ctx.ReplaceScopeVariables(uri)
-	reqURL := fmt.Sprintf("%s%s", ctx.baseURL, uri)
+	reqURL := ctx.buildRequestURL(uri)
 	jsonBody := ctx.ReplaceScopeVariables(requestBody.Content)
 	//todo
 	var jsonBodyBytes = []byte(jsonBody)
@@ -570,6 +565,12 @@ func (ctx *ApiContext) logResponse(response *http.Response) {
 
 	dump, _ := httputil.DumpResponse(response, true)
 	log.Println(string(dump))
+}
+
+// buildRequestURL concatenates the given URI and the base URL after replacing scope variables.
+func (ctx *ApiContext) buildRequestURL(uri string) string {
+	uri = ctx.ReplaceScopeVariables(uri)
+	return ctx.baseURL + uri
 }
 
 // WaitForSomeTime halt for some time.

--- a/apicontext_test.go
+++ b/apicontext_test.go
@@ -142,9 +142,14 @@ func TestApiContext_ISendRequestTo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := ctx.ISendRequestTo("GET", "/")
+	if err := ctx.StoreScopeData("id", "123"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ctx.ISendRequestTo("GET", "/resource/`##id`")
 
 	assert.Nil(t, err)
+	assert.Equal(t, "/resource/123", ctx.lastRequest.URL.Path)
 	assert.NotNil(t, ctx.lastResponse)
 	assert.Equal(t, 200, ctx.lastResponse.StatusCode)
 	assert.NotNil(t, ctx.TheResponseCodeShouldBe(400))
@@ -207,12 +212,17 @@ func TestApiContext_ISendRequestToWithFormBody(t *testing.T) {
 		},
 	}
 
-	err := ctx.ISendRequestToWithFormBody("POST", "/", dt)
+	if err := ctx.StoreScopeData("id", "123"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ctx.ISendRequestToWithFormBody("PUT", "/resource/`##id`", dt)
 
 	assert.Nil(t, err)
+	assert.Equal(t, "/resource/123", ctx.lastRequest.URL.Path)
 	assert.NotNil(t, ctx.lastResponse)
 	assert.Equal(t, 200, ctx.lastResponse.StatusCode)
-	assert.Equal(t, "POST", ctx.lastRequest.Method)
+	assert.Equal(t, "PUT", ctx.lastRequest.Method)
 }
 
 func TestApiContext_ISendRequestToWithBody(t *testing.T) {
@@ -238,15 +248,20 @@ func TestApiContext_ISendRequestToWithBody(t *testing.T) {
 		t.Fatalf("cannot set header on the request %v", err)
 	}
 
+	if err := ctx.StoreScopeData("id", "123"); err != nil {
+		t.Fatal(err)
+	}
+
 	reqBody := "{ \"name\": \"Bruno\"}"
-	err := ctx.ISendRequestToWithBody("POST", "/", &godog.DocString{
+	err := ctx.ISendRequestToWithBody("PUT", "/resource/`##id`", &godog.DocString{
 		Content: reqBody,
 	})
 
 	assert.Nil(t, err)
+	assert.Equal(t, "/resource/123", ctx.lastRequest.URL.Path)
 	assert.NotNil(t, ctx.lastResponse)
 	assert.Equal(t, 200, ctx.lastResponse.StatusCode)
-	assert.Equal(t, "POST", ctx.lastRequest.Method)
+	assert.Equal(t, "PUT", ctx.lastRequest.Method)
 }
 
 func TestApiContext_TheResponseHeaderShouldHaveValue(t *testing.T) {


### PR DESCRIPTION
These changes allow the usage of scope variables within URIs. This can be helpful to create scenarios in which you would want to request URLs with dynamic segments (e.g. resource IDs). To avoid repetition, I created a new helper function to build Request URLs by concatenating the URI and the base URL while replacing scope variables.

### Example scenario flow

1. A POST request creates a new resource and responds with the new resource ID (e.g. 123)
2. The resource ID is extracted from the response and saved into a scope variable (e.g. "id")
3. A GET request to the newly created resource is made (e.g. /resource/`##id`)
4. The scenario verifies that the status code equals 200 (not 404)