### PR TITLE
Add support for multiple input types for scope variables

### DIFF
--- a/apicontext.go
+++ b/apicontext.go
@@ -388,6 +388,7 @@ func (ctx *ApiContext) TheJSONPathShouldHaveValue(pathExpr string, expectedValue
 // TheJSONPathShouldMatch Validates Checks if the the value from the specified json path matches the specified pattern.
 func (ctx *ApiContext) TheJSONPathShouldMatch(pathExpr string, pattern string) error {
 	var jsonData interface{}
+	var match bool
 
 	if err := json.Unmarshal([]byte(ctx.lastResponse.Body), &jsonData); err != nil {
 		return err
@@ -399,7 +400,12 @@ func (ctx *ApiContext) TheJSONPathShouldMatch(pathExpr string, pattern string) e
 		return err
 	}
 
-	match, err := regexp.MatchString(pattern, value.(string))
+	switch v := value.(type) {
+	case string:
+		match, err = regexp.MatchString(pattern, v)
+	default:
+		match, err = regexp.MatchString(pattern, fmt.Sprint(v))
+	}
 
 	if err != nil {
 		return err
@@ -534,7 +540,7 @@ func (ctx *ApiContext) TheResponseShouldMatchJsonSchema(path string) error {
 			schemaErrors = append(schemaErrors, error.String())
 		}
 
-		return fmt.Errorf("The response is not valid according to the specified schema %s\n %v", path, schemaErrors)
+		return fmt.Errorf("the response is not valid according to the specified schema %s\n %v", path, schemaErrors)
 	}
 
 	return nil
@@ -604,7 +610,12 @@ func (ctx *ApiContext) StoreJsonPathValue(pathExpr string, scopeKeyName string) 
 	if err != nil {
 		return err
 	}
-	ctx.scope[scopeKeyName] = actualValue.(string)
+	switch v := actualValue.(type) {
+	case string:
+		ctx.scope[scopeKeyName] = v
+	default:
+		ctx.scope[scopeKeyName] = fmt.Sprint(v)
+	}
 	return nil
 }
 

--- a/apicontext_test.go
+++ b/apicontext_test.go
@@ -549,6 +549,10 @@ func TestApiContext_StoreJsonPathValue(t *testing.T) {
 	assert.NotNil(t, ctx.lastResponse)
 	assert.Nil(t, ctx.StoreJsonPathValue("$.a", "hello"))
 	assert.Nil(t, ctx.TheScopeVariableShouldHaveValue("hello", "a"))
+	assert.Nil(t, ctx.StoreJsonPathValue("$.b", "number"))
+	assert.Nil(t, ctx.TheScopeVariableShouldHaveValue("number", "2"))
+	assert.Nil(t, ctx.StoreJsonPathValue("$.c", "float"))
+	assert.Nil(t, ctx.TheScopeVariableShouldHaveValue("float", "3.5"))
 }
 
 func TestApiContext_ReplaceScopeVariables(t *testing.T) {


### PR DESCRIPTION
These changes allow the "I store the value of body path" step to be used with any type of json value. Before it was just possible to read string properties.